### PR TITLE
Add APA title crawler

### DIFF
--- a/.github/workflows/crawl_titles.yml
+++ b/.github/workflows/crawl_titles.yml
@@ -1,0 +1,23 @@
+name: Crawl APA Titles
+
+on:
+  workflow_dispatch:
+
+jobs:
+  crawl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run crawler
+        run: python apa_title_crawler.py
+      - name: Upload titles artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: apa-titles
+          path: apa_titles.json

--- a/apa_title_crawler.py
+++ b/apa_title_crawler.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Simple crawler to collect APA document titles from the Dutch Tax Authority website."""
+
+import requests
+from bs4 import BeautifulSoup
+import re
+import time
+import json
+from urllib.parse import urljoin
+from typing import Set, List
+import logging
+
+
+class APATitleCrawler:
+    """Crawl APA pages and collect document titles."""
+
+    def __init__(self, base_url: str, delay: float = 1.0):
+        self.base_url = base_url
+        self.delay = delay
+        self.session = requests.Session()
+        self.session.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+        })
+        self.visited: Set[str] = set()
+        self.titles: Set[str] = set()
+        logging.basicConfig(level=logging.INFO,
+                            format='%(asctime)s - %(levelname)s - %(message)s')
+        self.logger = logging.getLogger(__name__)
+
+    def fetch(self, url: str) -> BeautifulSoup | None:
+        """Fetch URL and return BeautifulSoup object."""
+        try:
+            self.logger.info("Fetching %s", url)
+            resp = self.session.get(url, timeout=30)
+            resp.raise_for_status()
+            return BeautifulSoup(resp.text, "lxml")
+        except Exception as exc:
+            self.logger.warning("Failed to fetch %s: %s", url, exc)
+            return None
+
+    def extract_titles(self, soup: BeautifulSoup) -> None:
+        """Extract APA titles from given soup."""
+        pattern = re.compile(r"\b\d{8}\s+APA\s+\d{6}\b")
+        for text in soup.stripped_strings:
+            m = pattern.search(text)
+            if m:
+                self.titles.add(m.group())
+
+    def crawl_page(self, url: str) -> None:
+        if url in self.visited:
+            return
+        self.visited.add(url)
+        soup = self.fetch(url)
+        if not soup:
+            return
+        self.extract_titles(soup)
+        for link in soup.find_all("a", href=True):
+            href = link["href"]
+            if href.startswith("#"):
+                continue
+            full = urljoin(url, href)
+            if self.base_url in full and full not in self.visited:
+                time.sleep(self.delay)
+                self.crawl_page(full)
+
+    def crawl(self) -> List[str]:
+        self.crawl_page(self.base_url)
+        return sorted(self.titles)
+
+
+def main() -> None:
+    base_url = (
+        "https://www.belastingdienst.nl/wps/wcm/connect/"
+        "bldcontentnl/standaard_functies/prive/contact/"
+        "rechten_en_plichten_bij_de_belastingdienst/ruling/apa"
+    )
+    crawler = APATitleCrawler(base_url)
+    titles = crawler.crawl()
+    print("Found titles:")
+    for t in titles:
+        print(t)
+    with open("apa_titles.json", "w", encoding="utf-8") as f:
+        json.dump({"titles": titles}, f, indent=2, ensure_ascii=False)
+    print("Saved titles to apa_titles.json")
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,18 @@ crawler.save_results("my_results.json")
 crawler.download_pdfs("my_pdfs")
 ```
 
+### APA Title Crawler
+
+To crawl only the list of APA titles without downloading PDFs:
+
+```bash
+python apa_title_crawler.py
+```
+
+This generates `apa_titles.json` containing all titles found on the site. The
+workflow in `.github/workflows/crawl_titles.yml` can be triggered manually to
+produce this file as a build artifact.
+
 ## Output
 
 ### JSON Results


### PR DESCRIPTION
## Summary
- add APA title crawler script
- create GitHub Actions workflow to export titles as artifact
- update README with usage instructions

## Testing
- `python -m py_compile apa_title_crawler.py`
- `python -m py_compile apa_pdf_crawler.py`


------
https://chatgpt.com/codex/tasks/task_e_684c05e7b0248329aca11a068d91c70a