### PR TITLE
Add CSV and text export for APA titles

### DIFF
--- a/.github/workflows/crawl_titles.yml
+++ b/.github/workflows/crawl_titles.yml
@@ -20,4 +20,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: apa-titles
-          path: apa_titles.json
+          path: |
+            apa_titles.json
+            apa_titles.csv
+            apa_titles.txt

--- a/apa_title_crawler.py
+++ b/apa_title_crawler.py
@@ -6,6 +6,7 @@ from bs4 import BeautifulSoup
 import re
 import time
 import json
+import csv
 from urllib.parse import urljoin
 from typing import Set, List
 import logging
@@ -82,6 +83,20 @@ def main() -> None:
     with open("apa_titles.json", "w", encoding="utf-8") as f:
         json.dump({"titles": titles}, f, indent=2, ensure_ascii=False)
     print("Saved titles to apa_titles.json")
+
+    # Also write titles to CSV for easier editing in Excel
+    with open("apa_titles.csv", "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["title"])
+        for t in titles:
+            writer.writerow([t])
+    print("Saved titles to apa_titles.csv")
+
+    # Write plain text file with one title per line
+    with open("apa_titles.txt", "w", encoding="utf-8") as f:
+        for t in titles:
+            f.write(t + "\n")
+    print("Saved titles to apa_titles.txt")
 
 
 if __name__ == "__main__":

--- a/gitignore.txt
+++ b/gitignore.txt
@@ -73,6 +73,9 @@ Thumbs.db
 # Project specific
 *.log
 apa_documents.json
+apa_titles.json
+apa_titles.csv
+apa_titles.txt
 pdfs/
 downloads/
 results/

--- a/readme.md
+++ b/readme.md
@@ -86,9 +86,10 @@ To crawl only the list of APA titles without downloading PDFs:
 python apa_title_crawler.py
 ```
 
-This generates `apa_titles.json` containing all titles found on the site. The
-workflow in `.github/workflows/crawl_titles.yml` can be triggered manually to
-produce this file as a build artifact.
+This generates `apa_titles.json`, `apa_titles.csv`, and `apa_titles.txt`
+containing all titles found on the site. The workflow in
+`.github/workflows/crawl_titles.yml` can be triggered manually to produce these
+files as build artifacts.
 
 ## Output
 


### PR DESCRIPTION
## Summary
- export APA titles to `apa_titles.csv` and `apa_titles.txt` as well as JSON
- upload all three files as artifacts in workflow
- document new outputs in README
- ignore generated title files in git

## Testing
- `python -m py_compile apa_pdf_crawler.py apa_title_crawler.py`

------
https://chatgpt.com/codex/tasks/task_e_685abdd608708329a31420c775b61221